### PR TITLE
versions.tf: hcloud_provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.23.0"
+      version = ">= 1.23, < 2"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
Allow modules importing this module (or vice versa) to use higher
version of hcloud_provider.
